### PR TITLE
fixing hanging quote on build badge status link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Netvote Smart Contracts
 ======================
-[![Build Status](https://travis-ci.org/netvote/elections-solidity.svg?branch=master")](https://travis-ci.org/netvote/elections-solidity)
+[![Build Status](https://travis-ci.org/netvote/elections-solidity.svg?branch=master)](https://travis-ci.org/netvote/elections-solidity)
 [![Coverage Status](https://codecov.io/gh/netvote/elections-solidity/branch/master/graph/badge.svg)](https://codecov.io/gh/netvote/elections-solidity)
 
 <img src="https://s3.amazonaws.com/netvote-docs/nv.png" alt="Logo"  height="35%" width="35%"/>


### PR DESCRIPTION
I added quote where it shouldn't be, and it broke the build badge