### PR TITLE
add no-removal set to avoid bookkeeping

### DIFF
--- a/contracts/elections/BasePool.sol
+++ b/contracts/elections/BasePool.sol
@@ -21,7 +21,7 @@ pragma solidity ^0.4.17;
 
 import "./BaseElection.sol";
 import "./links/BallotRegistry.sol";
-import "../lib/Bytes32Set.sol";
+import "../lib/NoRemovalBytes32Set.sol";
 
 
 /**
@@ -30,9 +30,9 @@ import "../lib/Bytes32Set.sol";
  * This maps a set of ballots for the purposes of ballot iteration.
  */
 contract BasePool is BallotRegistry {
-    using Bytes32Set for Bytes32Set.SetData;
+    using NoRemovalBytes32Set for NoRemovalBytes32Set.SetData;
 
-    Bytes32Set.SetData voteIdSet;
+    NoRemovalBytes32Set.SetData voteIdSet;
 
     address public election;
     string public createdBy;

--- a/contracts/lib/NoRemovalBytes32Set.sol
+++ b/contracts/lib/NoRemovalBytes32Set.sol
@@ -1,0 +1,52 @@
+// ------------------------------------------------------------------------------
+// This file is part of netvote.
+//
+// netvote is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// netvote is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with solidity.  If not, see <http://www.gnu.org/licenses/>
+//
+// (c) 2017 netvote contributors.
+//------------------------------------------------------------------------------
+
+pragma solidity ^0.4.17;
+
+
+/**
+ * @title NoRemovalBytes32Set
+ * @dev iterable map of bytes32 that has no way to remove (cheaper bookkeeping)
+ */
+library NoRemovalBytes32Set {
+
+    struct SetData {
+        mapping(bytes32 => bool) entryExists;
+        bytes32[] entries;
+    }
+
+    function getAt(SetData storage self, uint256 index) public constant returns (bytes32) {
+        return self.entries[index];
+    }
+
+    function contains(SetData storage self, bytes32 b) public constant returns (bool) {
+        return self.entryExists[b];
+    }
+
+    function size(SetData storage self) public constant returns (uint256) {
+        return self.entries.length;
+    }
+
+    function put(SetData storage self, bytes32 b) public {
+        if (!self.entryExists[b]) {
+            self.entryExists[b] = true;
+            self.entries.push(b);
+        }
+    }
+}

--- a/migrations/4_no_removal_bytes32_set_migration.js
+++ b/migrations/4_no_removal_bytes32_set_migration.js
@@ -1,0 +1,12 @@
+let NoRemovalBytes32Set = artifacts.require("./lib/NoRemovalBytes32Set.sol");
+let TieredBallot = artifacts.require("./elections/tiered/TieredBallot.sol");
+let TieredElection = artifacts.require("./elections/tiered/TieredElection.sol");
+let TieredPool = artifacts.require("./elections/tiered/TieredPool.sol");
+let BallotRegistry = artifacts.require("./elections/links/BallotRegistry.sol");
+let PoolRegistry = artifacts.require("./elections/links/PoolRegistry.sol");
+let BasicElection = artifacts.require("./elections/basic/BasicElection.sol");
+
+module.exports = function(deployer) {
+    deployer.deploy(NoRemovalBytes32Set);
+    deployer.link(NoRemovalBytes32Set, [TieredElection, TieredBallot, TieredPool, BasicElection, BallotRegistry, PoolRegistry]);
+};

--- a/test/solidity-libraries/TestNoRemovalBytes32Set.sol
+++ b/test/solidity-libraries/TestNoRemovalBytes32Set.sol
@@ -46,9 +46,6 @@ contract TestNoRemovalBytes32Set {
         set.put(testData2);
         Assert.equal(set.size(), 2, "expected size of 2");
 
-        // this is OK because contains() and size()-based iteration should be used instead
-        Assert.equal(set.indexOf(notIncluded), 0, "expected index 0");
-
         //getAt
         Assert.equal(set.getAt(0), testData1, "expected testData1");
         Assert.equal(set.getAt(1), testData2, "expected testData2");

--- a/test/solidity-libraries/TestNoRemovalBytes32Set.sol
+++ b/test/solidity-libraries/TestNoRemovalBytes32Set.sol
@@ -1,0 +1,62 @@
+pragma solidity ^0.4.17;
+
+import "truffle/Assert.sol";
+import "truffle/DeployedAddresses.sol";
+import "../../contracts/lib/NoRemovalBytes32Set.sol";
+
+// this avoids a warning error for an uninitialized Set
+contract SetWrapper {
+    using NoRemovalBytes32Set for NoRemovalBytes32Set.SetData;
+    NoRemovalBytes32Set.SetData set;
+
+    function getAt(uint256 index) public constant returns (bytes32) {
+        return set.getAt(index);
+    }
+
+    function contains(bytes32 a) public constant returns (bool) {
+        return set.contains(a);
+    }
+
+    function size() public constant returns (uint256) {
+        return set.size();
+    }
+
+    function put(bytes32 a) public {
+        return set.put(a);
+    }
+}
+
+contract TestNoRemovalBytes32Set {
+    using NoRemovalBytes32Set for NoRemovalBytes32Set.SetData;
+
+    function testTwoItems() public {
+        SetWrapper set = new SetWrapper();
+
+        bytes32 testData1 = keccak256("test1");
+        bytes32 testData2 = keccak256("test2");
+        bytes32 notIncluded = keccak256("test3");
+
+        Assert.equal(set.size(), 0, "expected size of 0 before adding");
+        set.put(testData1);
+        Assert.equal(set.size(), 1, "expected size of 1 before adding");
+        set.put(testData2);
+        Assert.equal(set.size(), 2, "expected size of 2");
+
+        // duplicate insert
+        set.put(testData2);
+        Assert.equal(set.size(), 2, "expected size of 2");
+
+        // this is OK because contains() and size()-based iteration should be used instead
+        Assert.equal(set.indexOf(notIncluded), 0, "expected index 0");
+
+        //getAt
+        Assert.equal(set.getAt(0), testData1, "expected testData1");
+        Assert.equal(set.getAt(1), testData2, "expected testData2");
+
+        //contains
+        Assert.isTrue(set.contains(testData1), "expected contains testData1");
+        Assert.isTrue(set.contains(testData2), "expected contains testData2");
+        Assert.isFalse(set.contains(notIncluded), "expected contains testData2");
+
+    }
+}


### PR DESCRIPTION
- votes cannot be removed, so our generic set implementation is inefficient
- avoids keeping up with entry index 
- we never ask for indexOf of votes, so no loss in functionality