### PR TITLE
Add external authorization to contracts

### DIFF
--- a/contracts/auth/ExternalAuthorizable.sol
+++ b/contracts/auth/ExternalAuthorizable.sol
@@ -1,0 +1,43 @@
+// ------------------------------------------------------------------------------
+// This file is part of netvote.
+//
+// netvote is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// netvote is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with solidity.  If not, see <http://www.gnu.org/licenses/>
+//
+// (c) 2017 netvote contributors.
+//------------------------------------------------------------------------------
+
+pragma solidity ^0.4.17;
+
+import "./Adminable.sol";
+
+
+/**
+ * @title ExternalAuthorizable
+ * @dev Allows an external system to ask whether an entry is authorized
+ */
+contract ExternalAuthorizable is Adminable {
+    mapping (bytes32 => bool) authorized;
+
+    function isAuthorized(bytes32 entry) public constant returns (bool) {
+        return authorized[entry];
+    }
+
+    function addAuthorized(bytes32 entry) public admin {
+        authorized[entry] = true;
+    }
+
+    function removeAuthorized(bytes32 entry) public admin {
+        authorized[entry] = false;
+    }
+}

--- a/contracts/elections/BaseElection.sol
+++ b/contracts/elections/BaseElection.sol
@@ -20,6 +20,7 @@
 pragma solidity ^0.4.17;
 
 import "./VoteAllowance.sol";
+import "../auth/ExternalAuthorizable.sol";
 import "./links/BallotRegistry.sol";
 import "./links/PoolRegistry.sol";
 import "../encryption/KeyHolder.sol";
@@ -30,7 +31,7 @@ import "zeppelin-solidity/contracts/ReentrancyGuard.sol";
  * @title BaseElection
  * @dev A base contract that transacts vote allowance and allows a key to be released
  */
-contract BaseElection is KeyHolder, ReentrancyGuard {
+contract BaseElection is ExternalAuthorizable, KeyHolder, ReentrancyGuard {
 
     VoteAllowance allowance;
     address allowanceAccount;
@@ -38,11 +39,13 @@ contract BaseElection is KeyHolder, ReentrancyGuard {
     string public electionType;
 
     function BaseElection(
+        bytes32 hashedUserId,
         address allowanceAddress,
         address acct,
         bool allowUpdates,
         address revealer) KeyHolder(revealer) public
     {
+        addAuthorized(hashedUserId);
         allowance = VoteAllowance(allowanceAddress);
         allowanceAccount = acct;
         allowVoteUpdates = allowUpdates;

--- a/contracts/elections/BasePool.sol
+++ b/contracts/elections/BasePool.sol
@@ -21,6 +21,7 @@ pragma solidity ^0.4.17;
 
 import "./BaseElection.sol";
 import "./links/BallotRegistry.sol";
+import "../auth/ExternalAuthorizable.sol";
 import "../lib/NoRemovalBytes32Set.sol";
 
 
@@ -29,7 +30,7 @@ import "../lib/NoRemovalBytes32Set.sol";
  * @dev A base contract receives and stores votes from a gateway address.
  * This maps a set of ballots for the purposes of ballot iteration.
  */
-contract BasePool is BallotRegistry {
+contract BasePool is ExternalAuthorizable, BallotRegistry {
     using NoRemovalBytes32Set for NoRemovalBytes32Set.SetData;
 
     NoRemovalBytes32Set.SetData voteIdSet;
@@ -46,9 +47,9 @@ contract BasePool is BallotRegistry {
 
     address public gateway;
 
-    function BasePool(string createdById, address el, address gw) public {
+    function BasePool(bytes32 hashedUserId, address el, address gw) public {
         require(el != address(0) && gw != address(0));
-        createdBy = createdById;
+        addAuthorized(hashedUserId);
         election = el;
         gateway = gw;
     }

--- a/contracts/elections/basic/BasicElection.sol
+++ b/contracts/elections/basic/BasicElection.sol
@@ -33,7 +33,7 @@ contract BasicElection is BasePool, BaseBallot, BaseElection {
 
     /**
       * @dev Constructor for creating a BasicElection
-      * @param createdById string reference for external systems (not for contract code)
+      * @param hashedUserId bytes32 sha3 hash of external userId
       * @param allowanceAddress The address of global allowance contract.
       * @param ownerOfAllowance The owner of the Vote Allowance to deduct from.
       * @param allowUpdates Whether to allow Voters to update their vote.
@@ -43,14 +43,14 @@ contract BasicElection is BasePool, BaseBallot, BaseElection {
       * @param autoActivate Automatically activate this election to allow votes
       */
     function BasicElection(
-        string createdById,
+        bytes32 hashedUserId,
         address allowanceAddress,
         address ownerOfAllowance,
         bool allowUpdates,
         address revealerAddress,
         string location,
         address gatewayAddress,
-        bool autoActivate) BaseElection(allowanceAddress, ownerOfAllowance, allowUpdates, revealerAddress) BaseBallot(msg.sender, location) BasePool(createdById, this, gatewayAddress) public
+        bool autoActivate) BaseElection(hashedUserId, allowanceAddress, ownerOfAllowance, allowUpdates, revealerAddress) BaseBallot(msg.sender, location) BasePool(hashedUserId, this, gatewayAddress) public
     {
         electionType = "BASIC";
         //pool lists this so it will comply with tally api contract (like tiered election)

--- a/contracts/elections/links/BallotRegistry.sol
+++ b/contracts/elections/links/BallotRegistry.sol
@@ -29,7 +29,7 @@ import "../../lib/AddressSet.sol";
  * which prevents duplicates and allows for removal.
  * Note: Order is not guaranteed.
  */
-contract BallotRegistry is Adminable, ElectionPhaseable {
+contract BallotRegistry is ElectionPhaseable {
     using AddressSet for AddressSet.SetData;
 
     AddressSet.SetData ballotSet;

--- a/contracts/elections/links/PoolRegistry.sol
+++ b/contracts/elections/links/PoolRegistry.sol
@@ -29,7 +29,7 @@ import "../../lib/AddressSet.sol";
  * which prevents duplicates and allows for removal.
  * Note: Order is not guaranteed.
  */
-contract PoolRegistry is Adminable, ElectionPhaseable {
+contract PoolRegistry is ElectionPhaseable {
     using AddressSet for AddressSet.SetData;
 
     AddressSet.SetData poolSet;

--- a/contracts/elections/tiered/TieredElection.sol
+++ b/contracts/elections/tiered/TieredElection.sol
@@ -38,10 +38,11 @@ contract TieredElection is BaseElection, BallotRegistry, PoolRegistry {
      * @param allowUpdates allow voters to update votes after voting
      */
     function TieredElection(
+        bytes32 hashedUserId,
         address allowanceAddress,
         address acct,
         bool allowUpdates,
-        address revealer) BaseElection(allowanceAddress, acct, allowUpdates, revealer) public
+        address revealer) BaseElection(hashedUserId, allowanceAddress, acct, allowUpdates, revealer) public
     {
         electionType = "TIERED";
     }

--- a/contracts/elections/tiered/TieredPool.sol
+++ b/contracts/elections/tiered/TieredPool.sol
@@ -31,7 +31,7 @@ import "./TieredElection.sol";
  */
 contract TieredPool is BasePool {
 
-    function TieredPool(string createdById, address el, address gw) BasePool(createdById, el, gw) public {
+    function TieredPool(bytes32 hashedUserId, address el, address gw) BasePool(hashedUserId, el, gw) public {
 
     }
 

--- a/test/contracts/ExternalAuthorizable.js
+++ b/test/contracts/ExternalAuthorizable.js
@@ -1,0 +1,57 @@
+// ------------------------------------------------------------------------------
+// This file is part of netvote.
+//
+// netvote is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// netvote is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with solidity.  If not, see <http://www.gnu.org/licenses/>
+//
+// (c) 2017 netvote contributors.
+//------------------------------------------------------------------------------
+
+
+let ExternalAuthorizable = artifacts.require("ExternalAuthorizable");
+
+let assertIsAuthorized = async (authorizable, uid, expectation) => {
+    let result = await authorizable.isAuthorized(web3.sha3(uid));
+    assert.equal(result, expectation, "expected "+uid+" to have isAuthorized="+expectation);
+};
+
+contract('ExternalAuthorizable', function (accounts) {
+    let owner;
+    let authorizable;
+    const goodUid = "good";
+    const badUid = "bad";
+
+    beforeEach(async () => {
+        owner = accounts[0];
+        authorizable = await ExternalAuthorizable.new({from: owner});
+    });
+
+    it("should start with no one as authorized", async function () {
+        await assertIsAuthorized(authorizable, goodUid, false);
+        await assertIsAuthorized(authorizable, badUid, false);
+    });
+
+    it("should add authorized", async function () {
+        await authorizable.addAuthorized(web3.sha3(goodUid));
+        await assertIsAuthorized(authorizable, goodUid, true);
+        await assertIsAuthorized(authorizable, badUid, false);
+    });
+
+    it("should remove authorized", async function () {
+        await authorizable.addAuthorized(web3.sha3(goodUid));
+        await authorizable.removeAuthorized(web3.sha3(goodUid));
+        await assertIsAuthorized(authorizable, goodUid, false);
+        await assertIsAuthorized(authorizable, badUid, false);
+    });
+
+});

--- a/test/contracts/TieredBallot.js
+++ b/test/contracts/TieredBallot.js
@@ -78,7 +78,7 @@ contract('TieredBallot', function (accounts) {
         let gateway = accounts[4];
 
         let otherElection = accounts[5];
-        election = await TieredElection.new(allowance, owner, false, gateway, {from: owner});
+        election = await TieredElection.new("uuid", allowance, owner, false, gateway, {from: owner});
         pool1 = await TieredPool.new("uuid", election.address, gateway, {from: owner});
         pool2 = await TieredPool.new("uuid", otherElection, gateway, {from: owner});
         ballot = await TieredBallot.new(election.address, owner, "test", {from: owner});

--- a/test/contracts/TieredPool.js
+++ b/test/contracts/TieredPool.js
@@ -69,7 +69,7 @@ contract('TieredPool', function (accounts) {
         gateway = accounts[3];
         allowance = accounts[4];
         let otherElection = accounts[5];
-        election = await TieredElection.new(allowance, owner, false, gateway, {from: owner});
+        election = await TieredElection.new("uuid", allowance, owner, false, gateway, {from: owner});
         pool = await TieredPool.new("uuid", election.address, gateway, {from: owner});
         ballot = await TieredBallot.new(election.address, owner, "test", {from: owner});
         ballot2 = await TieredBallot.new(otherElection, owner, "test", {from: owner});

--- a/test/end-to-end/jslib/tiered-election.js
+++ b/test/end-to-end/jslib/tiered-election.js
@@ -146,7 +146,7 @@ let createElection = async(config) => {
     log("create election");
     let va = await VoteAllowance.new({from: config.netvote});
     await va.addVotes(config.account.owner, config.account.allowance, {from: config.netvote});
-    config.contract = await TieredElection.new(va.address, config.account.owner, config.allowUpdates, config.netvote, {from: config.admin });
+    config.contract = await TieredElection.new("uuid", va.address, config.account.owner, config.allowUpdates, config.netvote, {from: config.admin });
     config = await measureGas(config, "Create Tiered Election");
     await va.addElection(config.contract.address, {from: config.account.owner});
     config = await measureGas(config, "Authorize Election for Allowance");


### PR DESCRIPTION
- evolving contract for multi-tier, to allow for authorization for encryption key posting
- one can now delegate multiple external uids that can be authorized for external actions