### PR TITLE
Add withdraw votes methods to BaseElection

### DIFF
--- a/contracts/elections/BaseElection.sol
+++ b/contracts/elections/BaseElection.sol
@@ -33,7 +33,7 @@ import "zeppelin-solidity/contracts/ReentrancyGuard.sol";
  */
 contract BaseElection is ExternalAuthorizable, KeyHolder, ReentrancyGuard {
 
-    Vote public voteTokenContract;
+    Vote public voteToken;
     address allowanceAccount;
     bool public allowVoteUpdates;
     string public electionType;
@@ -46,12 +46,26 @@ contract BaseElection is ExternalAuthorizable, KeyHolder, ReentrancyGuard {
         address revealer) KeyHolder(revealer) public
     {
         addAuthorized(hashedUserId);
-        voteTokenContract = Vote(tokenContractAddress);
+        voteToken = Vote(tokenContractAddress);
         allowanceAccount = acct;
         allowVoteUpdates = allowUpdates;
     }
 
+    function updateAllowanceAcct(address acct) public admin {
+        allowanceAccount = acct;
+    }
+
+    function withdrawAllVotes() public {
+        require(msg.sender == allowanceAccount);
+        voteToken.transfer(allowanceAccount, voteToken.balanceOf(this));
+    }
+
+    function withdrawVotes(uint256 value) public {
+        require(msg.sender == allowanceAccount);
+        voteToken.transfer(allowanceAccount, value);
+    }
+
     function deductVote() public voting nonReentrant {
-        voteTokenContract.spendVote();
+        voteToken.spendVote();
     }
 }

--- a/contracts/elections/BaseElection.sol
+++ b/contracts/elections/BaseElection.sol
@@ -34,7 +34,7 @@ import "zeppelin-solidity/contracts/ReentrancyGuard.sol";
 contract BaseElection is ExternalAuthorizable, KeyHolder, ReentrancyGuard {
 
     Vote public voteToken;
-    address allowanceAccount;
+    address voteOwner;
     bool public allowVoteUpdates;
     string public electionType;
 
@@ -47,22 +47,22 @@ contract BaseElection is ExternalAuthorizable, KeyHolder, ReentrancyGuard {
     {
         addAuthorized(hashedUserId);
         voteToken = Vote(tokenContractAddress);
-        allowanceAccount = acct;
+        voteOwner = acct;
         allowVoteUpdates = allowUpdates;
     }
 
-    function updateAllowanceAcct(address acct) public admin {
-        allowanceAccount = acct;
+    function setVoteOwner(address acct) public admin {
+        voteOwner = acct;
     }
 
     function withdrawAllVotes() public {
-        require(msg.sender == allowanceAccount);
-        voteToken.transfer(allowanceAccount, voteToken.balanceOf(this));
+        require(msg.sender == voteOwner);
+        voteToken.transfer(voteOwner, voteToken.balanceOf(this));
     }
 
     function withdrawVotes(uint256 value) public {
-        require(msg.sender == allowanceAccount);
-        voteToken.transfer(allowanceAccount, value);
+        require(msg.sender == voteOwner);
+        voteToken.transfer(voteOwner, value);
     }
 
     function deductVote() public voting nonReentrant {

--- a/contracts/token/Vote.sol
+++ b/contracts/token/Vote.sol
@@ -22,20 +22,19 @@ pragma solidity ^0.4.18;
 import "../state/Lockable.sol";
 import "zeppelin-solidity/contracts/token/MintableToken.sol";
 import "zeppelin-solidity/contracts/token/BurnableToken.sol";
-import "zeppelin-solidity/contracts/ReentrancyGuard.sol";
 
 
 /**
  * @title Vote
  * @dev Token for voting
  */
-contract Vote is Lockable, ReentrancyGuard, MintableToken, BurnableToken {
+contract Vote is Lockable, MintableToken, BurnableToken {
     string public name = "VOTE";
     string public symbol = "VOTE";
     uint8 public decimals = 18;
     event Vote(address election);
 
-    function spendVote() public unlocked nonReentrant {
+    function spendVote() public unlocked {
         require(balances[msg.sender] >= 1 ether);
         burn(1 ether);
         Vote(msg.sender);

--- a/test/contracts/BaseElection.js
+++ b/test/contracts/BaseElection.js
@@ -1,0 +1,122 @@
+// ------------------------------------------------------------------------------
+// This file is part of netvote.
+//
+// netvote is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// netvote is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with solidity.  If not, see <http://www.gnu.org/licenses/>
+//
+// (c) 2017 netvote contributors.
+//------------------------------------------------------------------------------
+
+let Vote = artifacts.require("Vote");
+let BaseElection = artifacts.require("BaseElection");
+
+let assertThrowsAsync = async (fn, regExp) => {
+    let f = () => {};
+    try {
+        await fn();
+    } catch(e) {
+        f = () => {throw e};
+    } finally {
+        assert.throws(f, regExp);
+    }
+};
+
+contract('BaseElection', function (accounts) {
+    let netvote;
+    let admin;
+    let admin2;
+    let election;
+    let vote;
+
+    let toWei = (num) => {
+        return web3.toWei(num, 'ether')
+    };
+
+    let assertBalance = async (addr, expected) => {
+        let bal = await vote.balanceOf(addr);
+        assert.equal(bal.toNumber(), toWei(expected));
+    };
+
+    beforeEach(async () => {
+        netvote = accounts[0];
+        admin = accounts[1];
+        admin2 = accounts[2];
+        vote = await Vote.new({from: netvote});
+        election = await BaseElection.new("uid", vote.address, admin, false, netvote, {from: admin});
+        await vote.mint(admin, toWei(50), {from: netvote});
+    });
+
+    it("should start with only admin with balance", async function () {
+        await assertBalance(election.address, 0);
+        await assertBalance(admin, 50);
+    });
+
+    it("should withdraw all to election", async function () {
+        await vote.transfer(election.address, toWei(25), {from: admin});
+        await assertBalance(election.address, 25);
+        await assertBalance(admin, 25);
+        await election.withdrawAllVotes({from: admin});
+        await assertBalance(election.address, 0);
+        await assertBalance(admin, 50);
+    });
+
+    it("should withdraw some to election", async function () {
+        await vote.transfer(election.address, toWei(25), {from: admin});
+        await assertBalance(election.address, 25);
+        await assertBalance(admin, 25);
+        await election.withdrawVotes(toWei(20), {from: admin});
+        await assertBalance(election.address, 5);
+        await assertBalance(admin, 45);
+    });
+
+    it("should delegate withdraw", async function () {
+        await vote.transfer(election.address, toWei(25), {from: admin});
+        await assertBalance(election.address, 25);
+        await assertBalance(admin, 25);
+        await election.setVoteOwner(admin2, {from: admin})
+        await election.withdrawVotes(toWei(20), {from: admin2});
+        await assertBalance(election.address, 5);
+        await assertBalance(admin, 25);
+        await assertBalance(admin2, 20);
+    });
+
+    it("should delegate withdraw all", async function () {
+        await vote.transfer(election.address, toWei(25), {from: admin});
+        await assertBalance(election.address, 25);
+        await assertBalance(admin, 25);
+        await election.setVoteOwner(admin2, {from: admin})
+        await election.withdrawAllVotes({from: admin2});
+        await assertBalance(election.address, 0);
+        await assertBalance(admin, 25);
+        await assertBalance(admin2, 25);
+    });
+
+    it("should not allow invalid user - withdrawl some", async function () {
+        await vote.transfer(election.address, toWei(25), {from: admin});
+        await assertBalance(election.address, 25);
+        await assertBalance(admin, 25);
+        await assertThrowsAsync(async function(){
+            await election.withdrawVotes(toWei(20), {from: admin2});
+        }, Error, "should throw Error")
+    });
+
+    it("should not allow invalid user - withdrawl all", async function () {
+        await vote.transfer(election.address, toWei(25), {from: admin});
+        await assertBalance(election.address, 25);
+        await assertBalance(admin, 25);
+        await assertThrowsAsync(async function(){
+            await election.withdrawAllVotes({from: admin2});
+        }, Error, "should throw Error")
+    });
+
+});

--- a/test/contracts/Vote.js
+++ b/test/contracts/Vote.js
@@ -56,7 +56,7 @@ contract('Vote', function (accounts) {
         admin = accounts[1];
         election = accounts[2];
         vote = await Vote.new({from: netvote});
-        await vote.mint(netvote, toWei(50));
+        await vote.mint(netvote, toWei(50), {from: netvote});
     });
 
     it("should start with only netvote with balance", async function () {

--- a/test/contracts/Vote.js
+++ b/test/contracts/Vote.js
@@ -97,4 +97,11 @@ contract('Vote', function (accounts) {
         }, Error, "should throw Error")
     });
 
+    it("should not allow spendVote with no balance", async function () {
+        await vote.transfer(admin, toWei(1), {from: netvote});
+        await assertThrowsAsync(async function(){
+            await vote.spendVote({from: election});
+        }, Error, "should throw Error")
+    });
+
 });

--- a/test/end-to-end/BasicElectionTests.js
+++ b/test/end-to-end/BasicElectionTests.js
@@ -187,6 +187,9 @@ contract('Auto-Activating Basic Election with Updates', function (accounts) {
     it("should have 1 vote left", async function () {
         let votesLeft = await config.allowanceContract.balanceOf(config.contract.address);
         assert.equal(votesLeft.toNumber(), web3.toWei(1, 'ether'), "expected 1 vote left (3 - 2 = 1)");
+        await config.contract.withdrawVotes(web3.toWei(1, 'ether'), {from: config.account.owner })
+        votesLeft = await config.allowanceContract.balanceOf(config.contract.address);
+        assert.equal(votesLeft.toNumber(), 0, "expected 0 votes left");
     });
 });
 
@@ -261,6 +264,9 @@ contract('Basic Election', function (accounts) {
     it("should have 1 vote left", async function () {
         let votesLeft = await config.allowanceContract.balanceOf(config.contract.address);
         assert.equal(votesLeft.toNumber(), web3.toWei(1, 'ether'), "expected 1 vote left (3 - 2 = 1)");
+        await config.contract.withdrawAllVotes({from: config.account.owner })
+        votesLeft = await config.allowanceContract.balanceOf(config.contract.address);
+        assert.equal(votesLeft.toNumber(), 0, "expected 0 votes left");
     });
 });
 

--- a/test/end-to-end/jslib/basic-election.js
+++ b/test/end-to-end/jslib/basic-election.js
@@ -129,7 +129,6 @@ let setupVoteToken = async(config) => {
     let va = await Vote.new({from: config.netvote});
     config.allowanceContract = va;
     await va.mint(config.account.owner, web3.toWei(50, "ether"), {from: config.netvote});
-    console.log("minted");
     return config;
 };
 


### PR DESCRIPTION
- `withdrawVotes(uint256 value)` will send `value` votes to `allowanceAddress`
- `withdrawAllVotes()` will send all votes from election to `allowanceAddress`
- `voteOwner` address is specified at creation 
- an Admin may change the `voteOwner` after creation