### PR TITLE
adding unique jti check on vote

### DIFF
--- a/contracts/elections/mock/MockElection.sol
+++ b/contracts/elections/mock/MockElection.sol
@@ -1,0 +1,29 @@
+// ------------------------------------------------------------------------------
+// This file is part of netvote.
+//
+// netvote is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// netvote is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with solidity.  If not, see <http://www.gnu.org/licenses/>
+//
+// (c) 2017 netvote contributors.
+//------------------------------------------------------------------------------
+
+pragma solidity ^0.4.17;
+
+
+contract MockElection {
+
+    function deductVote() public {
+
+    }
+
+}

--- a/contracts/elections/tiered/TieredPool.sol
+++ b/contracts/elections/tiered/TieredPool.sol
@@ -63,11 +63,22 @@ contract TieredPool is BasePool {
     }
 
     // for each ballot, cast vote for sender, store vote to pool
-    function castVote(bytes32 voteId, string vote, string passphrase) public voting notDuplicate(voteId) onlyGateway {
+    function castVote(
+        bytes32 voteId,
+        string vote,
+        string passphrase,
+        bytes32 jti) public voting notDuplicate(voteId) onlyGateway
+    {
+        super.castVote(
+            voteId,
+            vote,
+            passphrase,
+            jti
+        );
+
         for (uint256 i = 0; i<ballotSet.size(); i++) {
             TieredBallot(ballotSet.getAt(i)).castVote(voteId);
         }
-        super.castVote(voteId, vote, passphrase);
     }
 
 }

--- a/migrations/2_address_set_migration.js
+++ b/migrations/2_address_set_migration.js
@@ -2,11 +2,12 @@ let AddressSet = artifacts.require("./lib/AddressSet.sol");
 let TieredBallot = artifacts.require("./elections/tiered/TieredBallot.sol");
 let TieredElection = artifacts.require("./elections/tiered/TieredElection.sol");
 let TieredPool = artifacts.require("./elections/tiered/TieredPool.sol");
+let BasePool = artifacts.require("./elections/tiered/BasePool.sol");
 let BallotRegistry = artifacts.require("./elections/links/BallotRegistry.sol");
 let PoolRegistry = artifacts.require("./elections/links/PoolRegistry.sol");
 let BasicElection = artifacts.require("./elections/basic/BasicElection.sol");
 
 module.exports = function(deployer) {
     deployer.deploy(AddressSet);
-    deployer.link(AddressSet, [TieredElection, TieredBallot, TieredPool, BasicElection, BallotRegistry, PoolRegistry]);
+    deployer.link(AddressSet, [TieredElection, TieredBallot, TieredPool, BasePool, BasicElection, BallotRegistry, PoolRegistry]);
 };

--- a/migrations/4_no_removal_bytes32_set_migration.js
+++ b/migrations/4_no_removal_bytes32_set_migration.js
@@ -2,11 +2,12 @@ let NoRemovalBytes32Set = artifacts.require("./lib/NoRemovalBytes32Set.sol");
 let TieredBallot = artifacts.require("./elections/tiered/TieredBallot.sol");
 let TieredElection = artifacts.require("./elections/tiered/TieredElection.sol");
 let TieredPool = artifacts.require("./elections/tiered/TieredPool.sol");
+let BasePool = artifacts.require("./elections/tiered/BasePool.sol");
 let BallotRegistry = artifacts.require("./elections/links/BallotRegistry.sol");
 let PoolRegistry = artifacts.require("./elections/links/PoolRegistry.sol");
 let BasicElection = artifacts.require("./elections/basic/BasicElection.sol");
 
 module.exports = function(deployer) {
     deployer.deploy(NoRemovalBytes32Set);
-    deployer.link(NoRemovalBytes32Set, [TieredElection, TieredBallot, TieredPool, BasicElection, BallotRegistry, PoolRegistry]);
+    deployer.link(NoRemovalBytes32Set, [TieredElection, TieredBallot, TieredPool, BasePool, BasicElection, BallotRegistry, PoolRegistry]);
 };

--- a/test-gas/test-gas.js
+++ b/test-gas/test-gas.js
@@ -8,13 +8,13 @@ contract('GAS: Basic Election GAS Analysis', function (accounts) {
             ballotCount: 1,
             optionsPerBallot: 1,
             writeInCount: 0,
-            voteGasLimit: 185000
+            voteGasLimit: 187000
         },
         {
             ballotCount: 1,
             optionsPerBallot: 5,
             writeInCount: 0,
-            voteGasLimit: 210000
+            voteGasLimit: 229000
         },
         {
             ballotCount: 1,
@@ -26,13 +26,13 @@ contract('GAS: Basic Election GAS Analysis', function (accounts) {
             ballotCount: 1,
             optionsPerBallot: 10,
             writeInCount: 2,
-            voteGasLimit: 260000
+            voteGasLimit: 280000
         },
         {
             ballotCount: 1,
             optionsPerBallot: 20,
             writeInCount: 2,
-            voteGasLimit: 310000
+            voteGasLimit: 320000
         }
     ];
 

--- a/test/contracts/BasePool.js
+++ b/test/contracts/BasePool.js
@@ -1,0 +1,60 @@
+// ------------------------------------------------------------------------------
+// This file is part of netvote.
+//
+// netvote is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// netvote is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with solidity.  If not, see <http://www.gnu.org/licenses/>
+//
+// (c) 2017 netvote contributors.
+//------------------------------------------------------------------------------
+
+let BasePool = artifacts.require("BasePool");
+let MockElection = artifacts.require("MockElection");
+
+let assertThrowsAsync = async (fn, regExp) => {
+    let f = () => {};
+    try {
+        await fn();
+    } catch(e) {
+        f = () => {throw e};
+    } finally {
+        assert.throws(f, regExp);
+    }
+};
+
+contract('BasePool', function (accounts) {
+    let gateway;
+    let admin;
+    let pool;
+
+    beforeEach(async () => {
+        gateway = accounts[0];
+        admin = accounts[1];
+        let election = await MockElection.new({from: admin});
+        pool = await BasePool.new("uid",  election.address, gateway, {from: admin});
+
+        await pool.activate({from: admin});
+    });
+
+    it("should accept two different votes", async function () {
+        await pool.castVote("voteId", "vote", "passphrase", "jti", {from: gateway})
+        await pool.castVote("voteId2", "vote2", "passphrase2", "jti2", {from: gateway})
+    });
+
+    it("should prevent duplicate jti", async function () {
+        await pool.castVote("voteId", "vote", "passphrase", "jti", {from: gateway})
+        await assertThrowsAsync(async function() {
+            await pool.castVote("voteId2", "vote2", "passphrase2", "jti", {from: gateway})
+        }, Error, "should throw error");
+    });
+
+});

--- a/test/end-to-end/jslib/basic-election.js
+++ b/test/end-to-end/jslib/basic-election.js
@@ -177,11 +177,13 @@ let castVotes = async(config) => {
         if (config.voters.hasOwnProperty(name)) {
             let voter = config.voters[name];
             log("casting");
-            await config.contract.castVote(voter.voteId, voter.vote, "passphrase", {from: config.gateway});
+            let jti = voter.voteId+"1";
+            await config.contract.castVote(voter.voteId, voter.vote, "passphrase", jti, {from: config.gateway});
             config = await measureGas(config, "Cast Vote");
             if(voter.updateVote){
                 log("updating");
-                await config.contract.updateVote(voter.voteId, voter.updateVote, "passphrase", {from: config.gateway});
+                jti = jti+"2";
+                await config.contract.updateVote(voter.voteId, voter.updateVote, "passphrase", jti, {from: config.gateway});
                 config = await measureGas(config, "Update Vote");
             }
         }

--- a/test/end-to-end/jslib/tiered-election.js
+++ b/test/end-to-end/jslib/tiered-election.js
@@ -256,10 +256,12 @@ let castVotes = async(config) => {
         if (config.voters.hasOwnProperty(name)) {
             let voter = config.voters[name];
             let pool = config.pools[voter.pool].contract;
-            await pool.castVote(voter.address+"", voter.vote, "passphrase", {from: config.gateway});
+            let jti = voter.voteId+"1";
+            await pool.castVote(voter.address+"", voter.vote, "passphrase", jti, {from: config.gateway});
             config = await measureGas(config, "Cast Vote");
             if(voter.updateVote){
-                await pool.updateVote(voter.address+"", voter.updateVote, "passphrase", {from: config.gateway});
+                jti = voter.voteId+"2";
+                await pool.updateVote(voter.address+"", voter.updateVote, "passphrase", jti, {from: config.gateway});
                 config = await measureGas(config, "Update Vote");
             }
         }


### PR DESCRIPTION
- security optimization to prevent JWT replays
- a `sha3(hmac(jti, secret))` will be passed with vote to enforce unique JWT
- gateway will use same secret as hashing vote secret (deleted on close)