### PR TITLE
adding deploy migration for voteallowance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 .DS_Store
 node_modules
+lib
 build
 .ropsten.json
 coverage.json

--- a/migrations/6_deploy_voteallowance.js
+++ b/migrations/6_deploy_voteallowance.js
@@ -1,0 +1,5 @@
+let VoteAllowance = artifacts.require("./token/VoteAllowance.sol");
+
+module.exports = function(deployer) {
+    deployer.deploy(VoteAllowance);
+};


### PR DESCRIPTION
- allows us to use `VoteAllowance.deployed()` to get reference 