### PR TITLE
Batch add authids

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 VERSION=26
 
+.PHONY: build
+
 clean:
 	rm -rf ./build
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=25
+VERSION=26
 
 clean:
 	rm -rf ./build

--- a/contracts/elections/BasePool.sol
+++ b/contracts/elections/BasePool.sol
@@ -157,7 +157,7 @@ contract BasePool is ExternalAuthorizable, BallotRegistry {
     }
 
     function addAuthIds(bytes32[] _authIds) public admin {
-        for (uint256 i = 0; i<authIds.length; i++) {
+        for (uint256 i = 0; i<_authIds.length; i++) {
             authIdSet.put(_authIds[i]);
         }
     }

--- a/contracts/elections/BasePool.sol
+++ b/contracts/elections/BasePool.sol
@@ -156,12 +156,18 @@ contract BasePool is ExternalAuthorizable, BallotRegistry {
         authIdSet.put(authId);
     }
 
-    function getAuthIdCount() public view returns (uint256) {
-        return authIdSet.size();
+    function addAuthIds(bytes32[] _authIds) public admin {
+        for (uint256 i = 0; i <_authIds.length; i++) {
+            authIdSet.put(_authIds[i]);
+        }
     }
 
     function getAuthIdAt(uint256 index) public view returns (bytes32) {
         return authIdSet.getAt(index);
+    }
+
+    function getAuthIdCount() public view returns (uint) {
+        return authIdSet.size();
     }
 
 }

--- a/contracts/elections/BasePool.sol
+++ b/contracts/elections/BasePool.sol
@@ -157,7 +157,7 @@ contract BasePool is ExternalAuthorizable, BallotRegistry {
     }
 
     function addAuthIds(bytes32[] _authIds) public admin {
-        for (uint256 i = 0; i <_authIds.length; i++) {
+        for (uint256 i = 0; i<authIds.length; i++) {
             authIdSet.put(_authIds[i]);
         }
     }

--- a/test/contracts/BasePool.js
+++ b/test/contracts/BasePool.js
@@ -58,6 +58,21 @@ contract('BasePool', function (accounts) {
         assert.equal(web3.toAscii(authId2).replace(/\0/g,""), "test2")
     });
 
+    it("should batch insert auth Ids", async function () {
+        let authIds = []
+        let authIdNum = 100;
+        for(let i=0; i<authIdNum; i++){
+            authIds.push("test"+i);
+        }
+        await pool.addAuthIds(authIds, {from: admin});
+        let count = await pool.getAuthIdCount();
+        let authId1 = await pool.getAuthIdAt(0)
+        let authId2 = await pool.getAuthIdAt(1);
+        assert.equal(count, authIdNum, `should have ${authIdNum} authIds`)
+        assert.equal(web3.toAscii(authId1).replace(/\0/g,""), "test0")
+        assert.equal(web3.toAscii(authId2).replace(/\0/g,""), "test1")
+    });
+
     it("should not let just anybody insert auth Ids", async function () {
         await assertThrowsAsync(async function() {
             await pool.addAuthId("test1", {from: anybody})


### PR DESCRIPTION
- to avoid 1000s of authId transactions, this lets someone batch
- roughly 100 per transaction fits in default gas ranges